### PR TITLE
Add optional HTTP request timeout

### DIFF
--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -88,11 +88,15 @@ class Request(transport.Request):
         http (urllib3.request.RequestMethods): An instance of any urllib3
             class that implements :class:`~urllib3.request.RequestMethods`,
             usually :class:`urllib3.PoolManager`.
+        default_timeout (int): A number indicating the seconds for the default
+            HTTP request timeout. If not specified, the default timeout will be
+            ``None``.
 
     .. automethod:: __call__
     """
-    def __init__(self, http):
+    def __init__(self, http, default_timeout=None):
         self.http = http
+        self.default_timeout = default_timeout
 
     def __call__(self, url, method='GET', body=None, headers=None,
                  timeout=None, **kwargs):
@@ -118,8 +122,9 @@ class Request(transport.Request):
         """
         # urllib3 uses a sentinel default value for timeout, so only set it if
         # specified.
-        if timeout is not None:
-            kwargs['timeout'] = timeout
+        request_timeout = timeout or self.default_timeout
+        if request_timeout is not None:
+            kwargs['timeout'] = request_timeout
 
         try:
             _LOGGER.debug('Making request: %s %s', method, url)

--- a/tests/transport/compliance.py
+++ b/tests/transport/compliance.py
@@ -62,6 +62,14 @@ class RequestResponseTests(object):
         assert response.headers['x-test-header'] == 'value'
         assert response.data == b'Basic Content'
 
+    def test_request_default_timeout(self, server):
+        request = self.make_request(default_timeout=2)
+        response = request(url=server.url + '/basic', method='GET')
+
+        assert response.status == http_client.OK
+        assert response.headers['x-test-header'] == 'value'
+        assert response.data == b'Basic Content'
+
     def test_request_timeout(self, server):
         request = self.make_request()
         response = request(url=server.url + '/basic', method='GET', timeout=2)

--- a/tests/transport/test__http_client.py
+++ b/tests/transport/test__http_client.py
@@ -21,7 +21,7 @@ from tests.transport import compliance
 
 
 class TestRequestResponse(compliance.RequestResponseTests):
-    def make_request(self):
+    def make_request(self, default_timeout=None):
         return google.auth.transport._http_client.Request()
 
     def test_non_http(self):

--- a/tests/transport/test_requests.py
+++ b/tests/transport/test_requests.py
@@ -23,8 +23,9 @@ from tests.transport import compliance
 
 
 class TestRequestResponse(compliance.RequestResponseTests):
-    def make_request(self):
-        return google.auth.transport.requests.Request()
+    def make_request(self, default_timeout=None):
+        return google.auth.transport.requests.Request(
+            default_timeout=default_timeout)
 
     def test_timeout(self):
         http = mock.create_autospec(requests.Session, instance=True)

--- a/tests/transport/test_urllib3.py
+++ b/tests/transport/test_urllib3.py
@@ -22,9 +22,10 @@ from tests.transport import compliance
 
 
 class TestRequestResponse(compliance.RequestResponseTests):
-    def make_request(self):
+    def make_request(self, default_timeout=None):
         http = urllib3.PoolManager()
-        return google.auth.transport.urllib3.Request(http)
+        return google.auth.transport.urllib3.Request(
+            http, default_timeout=default_timeout)
 
     def test_timeout(self):
         http = mock.create_autospec(urllib3.PoolManager)


### PR DESCRIPTION
HTTP requests did not have the ability to time out when used as a
parameter for calls like: `google.oauth2.id_token.verify_oauth2_token`.
This commit adds the ability in the different implementations of the
`google.auth.transport.requests.Request` class to specify a
`default_timeout` to be used when no `timeout` is used in the actual
request call (like `request.get('/url', timeout=2)`.

A specific timeout can still be specified as an arg when making a
request, which overrides this new `default_timeout`.

An example for performing a `verify_oauth2_token` call could look
something like this if a two second timeout was desired:

```python
request = google.auth.transport.requests.Request(default_timeout=2)
id_info = google.oauth2.id_token.verify_oauth2_token(id_token,
                                                     request,
                                                     client_id)
```

This addresses #170.

edit: `timeout` => `default_timeout`