### PR TITLE
Fix missing timeout argument for http.client transport

### DIFF
--- a/google/auth/transport/_http_client.py
+++ b/google/auth/transport/_http_client.py
@@ -94,7 +94,7 @@ class Request(transport.Request):
                 'http.client transport only supports the http scheme, {}'
                 'was specified'.format(parts.scheme))
 
-        connection = http_client.HTTPConnection(parts.netloc)
+        connection = http_client.HTTPConnection(parts.netloc, timeout=timeout)
 
         try:
             _LOGGER.debug('Making request: %s %s', method, url)

--- a/tests/transport/compliance.py
+++ b/tests/transport/compliance.py
@@ -49,12 +49,12 @@ class RequestResponseTests(object):
         @app.route('/server_error')
         def server_error():
             return 'Error', http_client.INTERNAL_SERVER_ERROR
-        # pylint: enable=unused-variable
 
         @app.route('/wait')
         def wait():
             time.sleep(3)
             return 'Waited'
+        # pylint: enable=unused-variable
 
         server = WSGIServer(application=app.wsgi_app)
         server.start()


### PR DESCRIPTION
Fixes #173 