### PR TITLE
Fix retrieval of default project ID on Windows

### DIFF
--- a/google/auth/_cloud_sdk.py
+++ b/google/auth/_cloud_sdk.py
@@ -33,9 +33,11 @@ _WINDOWS_CONFIG_ROOT_ENV_VAR = 'APPDATA'
 # The name of the file in the Cloud SDK config that contains default
 # credentials.
 _CREDENTIALS_FILENAME = 'application_default_credentials.json'
+# The name of the Cloud SDK shell script
+_CLOUD_SDK_SHELL_SCRIPT = 'gcloud' if os.name != 'nt' else 'gcloud.cmd'
 # The command to get the Cloud SDK configuration
 _CLOUD_SDK_CONFIG_COMMAND = (
-    'gcloud', 'config', 'config-helper', '--format', 'json')
+    _CLOUD_SDK_SHELL_SCRIPT, 'config', 'config-helper', '--format', 'json')
 
 
 def get_config_path():

--- a/google/auth/_cloud_sdk.py
+++ b/google/auth/_cloud_sdk.py
@@ -34,10 +34,10 @@ _WINDOWS_CONFIG_ROOT_ENV_VAR = 'APPDATA'
 # credentials.
 _CREDENTIALS_FILENAME = 'application_default_credentials.json'
 # The name of the Cloud SDK shell script
-_CLOUD_SDK_SHELL_SCRIPT = 'gcloud' if os.name != 'nt' else 'gcloud.cmd'
+_CLOUD_SDK_POSIX_COMMAND = 'gcloud'
+_CLOUD_SDK_WINDOWS_COMMAND = 'gcloud.cmd'
 # The command to get the Cloud SDK configuration
-_CLOUD_SDK_CONFIG_COMMAND = (
-    _CLOUD_SDK_SHELL_SCRIPT, 'config', 'config-helper', '--format', 'json')
+_CLOUD_SDK_CONFIG_COMMAND = ('config', 'config-helper', '--format', 'json')
 
 
 def get_config_path():
@@ -116,10 +116,14 @@ def get_project_id():
     Returns:
         Optional[str]: The project ID.
     """
+    if os.name == 'nt':
+        command = _CLOUD_SDK_WINDOWS_COMMAND
+    else:
+        command = _CLOUD_SDK_POSIX_COMMAND
 
     try:
         output = subprocess.check_output(
-            _CLOUD_SDK_CONFIG_COMMAND,
+            (command,) + _CLOUD_SDK_CONFIG_COMMAND,
             stderr=subprocess.STDOUT)
     except (subprocess.CalledProcessError, OSError, IOError):
         return None

--- a/tests/test__cloud_sdk.py
+++ b/tests/test__cloud_sdk.py
@@ -65,6 +65,24 @@ def test_get_project_id_call_error(check_output):
     assert check_output.called
 
 
+@mock.patch('os.name', new='nt')
+def test_get_project_id_windows():
+    check_output_patch = mock.patch(
+        'subprocess.check_output', autospec=True,
+        return_value=CLOUD_SDK_CONFIG_FILE_DATA)
+
+    with check_output_patch as check_output:
+        project_id = _cloud_sdk.get_project_id()
+
+    assert project_id == 'example-project'
+    assert check_output.called
+    # Make sure the executable is `gcloud.cmd`.
+    args = check_output.call_args[0]
+    command = args[0]
+    executable = command[0]
+    assert executable == 'gcloud.cmd'
+
+
 @mock.patch(
     'google.auth._cloud_sdk.get_config_path', autospec=True)
 def test_get_application_default_credentials_path(get_config_dir):


### PR DESCRIPTION
- Fix for shell command call "subprocess.check_output(_CLOUD_SDK_CONFIG_COMMAND...)".
- Previously, it would trigger an error "WindowsError: [Error 2] The system cannot find the file specified". A workaround was to specify the env variable GCLOUD_PROJECT.
- With this patch, "gcloud" default project is successfully retrieved.