### PR TITLE
Adding `cryptography` Signer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/_build
 .nox/
 .tox/
 .cache/
+.pytest_cache/
 
 # Django test database
 db.sqlite3

--- a/google/auth/crypt/_cryptography_rsa.py
+++ b/google/auth/crypt/_cryptography_rsa.py
@@ -58,8 +58,20 @@ class RSAVerifier(base.Verifier):
             return False
 
     @classmethod
-    @_helpers.copy_docstring(base.Signer)
     def from_string(cls, public_key):
+        """Construct an Verifier instance from a public key or public
+        certificate string.
+
+        Args:
+            public_key (Union[str, bytes]): The public key in PEM format or the
+                x509 public key certificate.
+
+        Returns:
+            Verifier: The constructed verifier.
+
+        Raises:
+            ValueError: If the public key can't be parsed.
+        """
         public_key_data = _helpers.to_bytes(public_key)
 
         if _CERTIFICATE_MARKER in public_key_data:

--- a/google/auth/crypt/_cryptography_rsa.py
+++ b/google/auth/crypt/_cryptography_rsa.py
@@ -1,0 +1,83 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verifier and signer that use the ``cryptography`` library.
+
+This is a much faster implementation than the default (in
+``google.auth.crypt._python_rsa``), which depends on the pure-Python
+``rsa`` library.
+"""
+
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+
+from google.auth import _helpers
+from google.auth.crypt import base
+
+
+_BACKEND = backends.default_backend()
+_PADDING = padding.PKCS1v15()
+_SHA256 = hashes.SHA256()
+
+
+class CryptographySigner(base.Signer, base._FromServiceAccountMixin):
+    """Signs messages with a cryptography ``PKey`` private key.
+
+    Args:
+        private_key (cryptography.hazmat.backends.openssl.rsa._RSAPrivateKey):
+            The private key to sign with.
+        key_id (str): Optional key ID used to identify this private key. This
+            can be useful to associate the private key with its associated
+            public key or certificate.
+    """
+
+    def __init__(self, private_key, key_id=None):
+        self._key = private_key
+        self._key_id = key_id
+
+    @property
+    @_helpers.copy_docstring(base.Signer)
+    def key_id(self):
+        return self._key_id
+
+    @_helpers.copy_docstring(base.Signer)
+    def sign(self, message):
+        message = _helpers.to_bytes(message)
+        return self._key.sign(
+            message, _PADDING, _SHA256)
+
+    @classmethod
+    def from_string(cls, key, key_id=None):
+        """Construct a CryptographySigner from a private key in PEM format.
+
+        Args:
+            key (Union[bytes, str]): Private key in PEM format.
+            key_id (str): An optional key id used to identify the private key.
+
+        Returns:
+            google.auth.crypt._cryptography_rsa.CryptographySigner: The
+            constructed signer.
+
+        Raises:
+            ValueError: If ``key`` is not ``bytes`` or ``str`` (unicode).
+            UnicodeDecodeError: If ``key`` is ``bytes`` but cannot be decoded
+                into a UTF-8 ``str``.
+            ValueError: If ``cryptography`` "Could not deserialize key data."
+        """
+        message = _helpers.to_bytes(key)
+        private_key = serialization.load_pem_private_key(
+            key, password=None, backend=_BACKEND)
+        return cls(private_key, key_id=key_id)

--- a/google/auth/crypt/_cryptography_rsa.py
+++ b/google/auth/crypt/_cryptography_rsa.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Verifier and signer that use the ``cryptography`` library.
+"""RSA verifier and signer that use the ``cryptography`` library.
 
 This is a much faster implementation than the default (in
 ``google.auth.crypt._python_rsa``), which depends on the pure-Python
@@ -33,7 +33,7 @@ _PADDING = padding.PKCS1v15()
 _SHA256 = hashes.SHA256()
 
 
-class CryptographySigner(base.Signer, base._FromServiceAccountMixin):
+class RSASigner(base.Signer, base._FromServiceAccountMixin):
     """Signs messages with a cryptography ``PKey`` private key.
 
     Args:
@@ -61,14 +61,14 @@ class CryptographySigner(base.Signer, base._FromServiceAccountMixin):
 
     @classmethod
     def from_string(cls, key, key_id=None):
-        """Construct a CryptographySigner from a private key in PEM format.
+        """Construct a RSASigner from a private key in PEM format.
 
         Args:
             key (Union[bytes, str]): Private key in PEM format.
             key_id (str): An optional key id used to identify the private key.
 
         Returns:
-            google.auth.crypt._cryptography_rsa.CryptographySigner: The
+            google.auth.crypt._cryptography_rsa.RSASigner: The
             constructed signer.
 
         Raises:

--- a/google/auth/crypt/_cryptography_rsa.py
+++ b/google/auth/crypt/_cryptography_rsa.py
@@ -58,20 +58,8 @@ class RSAVerifier(base.Verifier):
             return False
 
     @classmethod
+    @_helpers.copy_docstring(base.Signer)
     def from_string(cls, public_key):
-        """Construct an Verifier instance from a public key or public
-        certificate string.
-
-        Args:
-            public_key (Union[str, bytes]): The public key in PEM format or the
-                x509 public key certificate.
-
-        Returns:
-            Verifier: The constructed verifier.
-
-        Raises:
-            ValueError: If the public_key can't be parsed.
-        """
         public_key_data = _helpers.to_bytes(public_key)
 
         if _CERTIFICATE_MARKER in public_key_data:

--- a/google/auth/crypt/_python_rsa.py
+++ b/google/auth/crypt/_python_rsa.py
@@ -21,9 +21,6 @@ certificates. There is no support for p12 files.
 
 from __future__ import absolute_import
 
-import io
-import json
-
 from pyasn1.codec.der import decoder
 from pyasn1_modules import pem
 from pyasn1_modules.rfc2459 import Certificate
@@ -41,8 +38,6 @@ _PKCS1_MARKER = ('-----BEGIN RSA PRIVATE KEY-----',
 _PKCS8_MARKER = ('-----BEGIN PRIVATE KEY-----',
                  '-----END PRIVATE KEY-----')
 _PKCS8_SPEC = PrivateKeyInfo()
-_JSON_FILE_PRIVATE_KEY = 'private_key'
-_JSON_FILE_PRIVATE_KEY_ID = 'private_key_id'
 
 
 def _bit_list_to_bytes(bit_list):
@@ -119,7 +114,7 @@ class RSAVerifier(base.Verifier):
         return cls(pubkey)
 
 
-class RSASigner(base.Signer):
+class RSASigner(base.Signer, base._FromServiceAccountMixin):
     """Signs messages with an RSA private key.
 
     Args:
@@ -179,43 +174,3 @@ class RSASigner(base.Signer):
             raise ValueError('No key could be detected.')
 
         return cls(private_key, key_id=key_id)
-
-    @classmethod
-    def from_service_account_info(cls, info):
-        """Creates a Signer instance instance from a dictionary containing
-        service account info in Google format.
-
-        Args:
-            info (Mapping[str, str]): The service account info in Google
-                format.
-
-        Returns:
-            google.auth.crypt.Signer: The constructed signer.
-
-        Raises:
-            ValueError: If the info is not in the expected format.
-        """
-        if _JSON_FILE_PRIVATE_KEY not in info:
-            raise ValueError(
-                'The private_key field was not found in the service account '
-                'info.')
-
-        return cls.from_string(
-            info[_JSON_FILE_PRIVATE_KEY],
-            info.get(_JSON_FILE_PRIVATE_KEY_ID))
-
-    @classmethod
-    def from_service_account_file(cls, filename):
-        """Creates a Signer instance from a service account .json file
-        in Google format.
-
-        Args:
-            filename (str): The path to the service account .json file.
-
-        Returns:
-            google.auth.crypt.Signer: The constructed signer.
-        """
-        with io.open(filename, 'r', encoding='utf-8') as json_file:
-            data = json.load(json_file)
-
-        return cls.from_service_account_info(data)

--- a/google/auth/crypt/_python_rsa.py
+++ b/google/auth/crypt/_python_rsa.py
@@ -114,7 +114,7 @@ class RSAVerifier(base.Verifier):
         return cls(pubkey)
 
 
-class RSASigner(base.Signer, base._FromServiceAccountMixin):
+class RSASigner(base.Signer, base.FromServiceAccountMixin):
     """Signs messages with an RSA private key.
 
     Args:

--- a/google/auth/crypt/base.py
+++ b/google/auth/crypt/base.py
@@ -70,12 +70,25 @@ class Signer(object):
         raise NotImplementedError('Sign must be implemented')
 
 
-class _FromServiceAccountMixin(object):
-    """Mix-in to enable factory constructors for a Signer.
+@six.add_metaclass(abc.ABCMeta)
+class FromServiceAccountMixin(object):
+    """Mix-in to enable factory constructors for a Signer."""
 
-    Assumes this class will be mixed in with a class that has
-    implemented a ``from_string`` class method.
-    """
+    @abc.abstractmethod
+    def from_string(cls, key, key_id=None):
+        """Construct an Signer instance from a private key string.
+
+        Args:
+            key (str): Private key as a string.
+            key_id (str): An optional key id used to identify the private key.
+
+        Returns:
+            google.auth.crypt.Signer: The constructed signer.
+
+        Raises:
+            ValueError: If the key cannot be parsed.
+        """
+        raise NotImplementedError('from_string must be implemented')
 
     @classmethod
     def from_service_account_info(cls, info):

--- a/google/auth/crypt/base.py
+++ b/google/auth/crypt/base.py
@@ -15,8 +15,14 @@
 """Base classes for cryptographic signers and verifiers."""
 
 import abc
+import io
+import json
 
 import six
+
+
+_JSON_FILE_PRIVATE_KEY = 'private_key'
+_JSON_FILE_PRIVATE_KEY_ID = 'private_key_id'
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -62,3 +68,51 @@ class Signer(object):
         # pylint: disable=missing-raises-doc,redundant-returns-doc
         # (pylint doesn't recognize that this is abstract)
         raise NotImplementedError('Sign must be implemented')
+
+
+class _FromServiceAccountMixin(object):
+    """Mix-in to enable factory constructors for a Signer.
+
+    Assumes this class will be mixed in with a class that has
+    implemented a ``from_string`` class method.
+    """
+
+    @classmethod
+    def from_service_account_info(cls, info):
+        """Creates a Signer instance instance from a dictionary containing
+        service account info in Google format.
+
+        Args:
+            info (Mapping[str, str]): The service account info in Google
+                format.
+
+        Returns:
+            google.auth.crypt.Signer: The constructed signer.
+
+        Raises:
+            ValueError: If the info is not in the expected format.
+        """
+        if _JSON_FILE_PRIVATE_KEY not in info:
+            raise ValueError(
+                'The private_key field was not found in the service account '
+                'info.')
+
+        return cls.from_string(
+            info[_JSON_FILE_PRIVATE_KEY],
+            info.get(_JSON_FILE_PRIVATE_KEY_ID))
+
+    @classmethod
+    def from_service_account_file(cls, filename):
+        """Creates a Signer instance from a service account .json file
+        in Google format.
+
+        Args:
+            filename (str): The path to the service account .json file.
+
+        Returns:
+            google.auth.crypt.Signer: The constructed signer.
+        """
+        with io.open(filename, 'r', encoding='utf-8') as json_file:
+            data = json.load(json_file)
+
+        return cls.from_service_account_info(data)

--- a/google/auth/crypt/rsa.py
+++ b/google/auth/crypt/rsa.py
@@ -16,12 +16,14 @@
 
 
 try:
+    # Prefer cryptograph-based RSA implementation.
     from google.auth.crypt import _cryptography_rsa
 
     RSASigner = _cryptography_rsa.RSASigner
     RSAVerifier = _cryptography_rsa.RSAVerifier
 except ImportError:  # pragma: NO COVER
-    # Fallback to pure-python RSA implementation
+    # Fallback to pure-python RSA implementation if cryptography is
+    # unavailable.
     from google.auth.crypt import _python_rsa
 
     RSASigner = _python_rsa.RSASigner

--- a/google/auth/crypt/rsa.py
+++ b/google/auth/crypt/rsa.py
@@ -17,7 +17,7 @@
 try:
     from google.auth.crypt import _cryptography_rsa
 
-    RSASigner = _cryptography_rsa.CryptographySigner
+    RSASigner = _cryptography_rsa.RSASigner
     RSAVerifier = NotImplemented
 except ImportError:
     from google.auth.crypt import _python_rsa

--- a/google/auth/crypt/rsa.py
+++ b/google/auth/crypt/rsa.py
@@ -14,13 +14,13 @@
 
 """RSA cryptography signer and verifier."""
 
+from google.auth.crypt import _python_rsa
+
 try:
     from google.auth.crypt import _cryptography_rsa
 
     RSASigner = _cryptography_rsa.RSASigner
-    RSAVerifier = NotImplemented
+    RSAVerifier = _python_rsa.RSAVerifier
 except ImportError:
-    from google.auth.crypt import _python_rsa
-
     RSASigner = _python_rsa.RSASigner
     RSAVerifier = _python_rsa.RSAVerifier

--- a/google/auth/crypt/rsa.py
+++ b/google/auth/crypt/rsa.py
@@ -14,7 +14,13 @@
 
 """RSA cryptography signer and verifier."""
 
-from google.auth.crypt import _python_rsa
+try:
+    from google.auth.crypt import _cryptography_rsa
 
-RSASigner = _python_rsa.RSASigner
-RSAVerifier = _python_rsa.RSAVerifier
+    RSASigner = _cryptography_rsa.CryptographySigner
+    RSAVerifier = NotImplemented
+except ImportError:
+    from google.auth.crypt import _python_rsa
+
+    RSASigner = _python_rsa.RSASigner
+    RSAVerifier = _python_rsa.RSAVerifier

--- a/google/auth/crypt/rsa.py
+++ b/google/auth/crypt/rsa.py
@@ -14,13 +14,15 @@
 
 """RSA cryptography signer and verifier."""
 
-from google.auth.crypt import _python_rsa
 
 try:
     from google.auth.crypt import _cryptography_rsa
 
     RSASigner = _cryptography_rsa.RSASigner
-    RSAVerifier = _python_rsa.RSAVerifier
-except ImportError:
+    RSAVerifier = _cryptography_rsa.RSAVerifier
+except ImportError:  # pragma: NO COVER
+    # Fallback to pure-python RSA implementation
+    from google.auth.crypt import _python_rsa
+
     RSASigner = _python_rsa.RSASigner
     RSAVerifier = _python_rsa.RSAVerifier

--- a/tests/crypt/test__cryptography_rsa.py
+++ b/tests/crypt/test__cryptography_rsa.py
@@ -1,0 +1,173 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+import pytest
+
+from google.auth import _helpers
+from google.auth.crypt import _cryptography_rsa
+from google.auth.crypt import base
+
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+
+# To generate privatekey.pem, privatekey.pub, and public_cert.pem:
+#   $ openssl req -new -newkey rsa:1024 -x509 -nodes -out public_cert.pem \
+#   >    -keyout privatekey.pem
+#   $ openssl rsa -in privatekey.pem -pubout -out privatekey.pub
+
+with open(os.path.join(DATA_DIR, 'privatekey.pem'), 'rb') as fh:
+    PRIVATE_KEY_BYTES = fh.read()
+    PKCS1_KEY_BYTES = PRIVATE_KEY_BYTES
+
+with open(os.path.join(DATA_DIR, 'privatekey.pub'), 'rb') as fh:
+    PUBLIC_KEY_BYTES = fh.read()
+
+with open(os.path.join(DATA_DIR, 'public_cert.pem'), 'rb') as fh:
+    PUBLIC_CERT_BYTES = fh.read()
+
+# To generate pem_from_pkcs12.pem and privatekey.p12:
+#   $ openssl pkcs12 -export -out privatekey.p12 -inkey privatekey.pem \
+#   >    -in public_cert.pem
+#   $ openssl pkcs12 -in privatekey.p12 -nocerts -nodes \
+#   >   -out pem_from_pkcs12.pem
+
+with open(os.path.join(DATA_DIR, 'pem_from_pkcs12.pem'), 'rb') as fh:
+    PKCS8_KEY_BYTES = fh.read()
+
+with open(os.path.join(DATA_DIR, 'privatekey.p12'), 'rb') as fh:
+    PKCS12_KEY_BYTES = fh.read()
+
+# The service account JSON file can be generated from the Google Cloud Console.
+SERVICE_ACCOUNT_JSON_FILE = os.path.join(DATA_DIR, 'service_account.json')
+
+with open(SERVICE_ACCOUNT_JSON_FILE, 'r') as fh:
+    SERVICE_ACCOUNT_INFO = json.load(fh)
+
+
+# class TestRSAVerifier(object):
+#     def test_verify_success(self):
+#         to_sign = b'foo'
+#         signer = _python_rsa.RSASigner.from_string(PRIVATE_KEY_BYTES)
+#         actual_signature = signer.sign(to_sign)
+
+#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
+#         assert verifier.verify(to_sign, actual_signature)
+
+#     def test_verify_unicode_success(self):
+#         to_sign = u'foo'
+#         signer = _python_rsa.RSASigner.from_string(PRIVATE_KEY_BYTES)
+#         actual_signature = signer.sign(to_sign)
+
+#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
+#         assert verifier.verify(to_sign, actual_signature)
+
+#     def test_verify_failure(self):
+#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
+#         bad_signature1 = b''
+#         assert not verifier.verify(b'foo', bad_signature1)
+#         bad_signature2 = b'a'
+#         assert not verifier.verify(b'foo', bad_signature2)
+
+#     def test_from_string_pub_key(self):
+#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
+#         assert isinstance(verifier, _python_rsa.RSAVerifier)
+#         assert isinstance(verifier._pubkey, rsa.key.PublicKey)
+
+#     def test_from_string_pub_key_unicode(self):
+#         public_key = _helpers.from_bytes(PUBLIC_KEY_BYTES)
+#         verifier = _python_rsa.RSAVerifier.from_string(public_key)
+#         assert isinstance(verifier, _python_rsa.RSAVerifier)
+#         assert isinstance(verifier._pubkey, rsa.key.PublicKey)
+
+#     def test_from_string_pub_cert(self):
+#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_CERT_BYTES)
+#         assert isinstance(verifier, _python_rsa.RSAVerifier)
+#         assert isinstance(verifier._pubkey, rsa.key.PublicKey)
+
+#     def test_from_string_pub_cert_unicode(self):
+#         public_cert = _helpers.from_bytes(PUBLIC_CERT_BYTES)
+#         verifier = _python_rsa.RSAVerifier.from_string(public_cert)
+#         assert isinstance(verifier, _python_rsa.RSAVerifier)
+#         assert isinstance(verifier._pubkey, rsa.key.PublicKey)
+
+#     def test_from_string_pub_cert_failure(self):
+#         cert_bytes = PUBLIC_CERT_BYTES
+#         true_der = rsa.pem.load_pem(cert_bytes, 'CERTIFICATE')
+#         load_pem_patch = mock.patch(
+#             'rsa.pem.load_pem', return_value=true_der + b'extra',
+#             autospec=True)
+
+#         with load_pem_patch as load_pem:
+#             with pytest.raises(ValueError):
+#                 _python_rsa.RSAVerifier.from_string(cert_bytes)
+#             load_pem.assert_called_once_with(cert_bytes, 'CERTIFICATE')
+
+
+class TestRSASigner(object):
+    def test_from_string_pkcs1(self):
+        signer = _cryptography_rsa.RSASigner.from_string(PKCS1_KEY_BYTES)
+        assert isinstance(signer, _cryptography_rsa.RSASigner)
+        assert isinstance(signer._key, rsa.RSAPrivateKey)
+
+    def test_from_string_pkcs1_unicode(self):
+        key_bytes = _helpers.from_bytes(PKCS1_KEY_BYTES)
+        signer = _cryptography_rsa.RSASigner.from_string(key_bytes)
+        assert isinstance(signer, _cryptography_rsa.RSASigner)
+        assert isinstance(signer._key, rsa.RSAPrivateKey)
+
+    def test_from_string_pkcs8(self):
+        signer = _cryptography_rsa.RSASigner.from_string(PKCS8_KEY_BYTES)
+        assert isinstance(signer, _cryptography_rsa.RSASigner)
+        assert isinstance(signer._key, rsa.RSAPrivateKey)
+
+    def test_from_string_pkcs8_unicode(self):
+        key_bytes = _helpers.from_bytes(PKCS8_KEY_BYTES)
+        signer = _cryptography_rsa.RSASigner.from_string(key_bytes)
+        assert isinstance(signer, _cryptography_rsa.RSASigner)
+        assert isinstance(signer._key, rsa.RSAPrivateKey)
+
+    def test_from_string_pkcs12(self):
+        with pytest.raises(ValueError):
+            _cryptography_rsa.RSASigner.from_string(PKCS12_KEY_BYTES)
+
+    def test_from_string_bogus_key(self):
+        key_bytes = 'bogus-key'
+        with pytest.raises(ValueError):
+            _cryptography_rsa.RSASigner.from_string(key_bytes)
+
+    def test_from_service_account_info(self):
+        signer = _cryptography_rsa.RSASigner.from_service_account_info(
+            SERVICE_ACCOUNT_INFO)
+
+        assert signer.key_id == SERVICE_ACCOUNT_INFO[
+            base._JSON_FILE_PRIVATE_KEY_ID]
+        assert isinstance(signer._key, rsa.RSAPrivateKey)
+
+    def test_from_service_account_info_missing_key(self):
+        with pytest.raises(ValueError) as excinfo:
+            _cryptography_rsa.RSASigner.from_service_account_info({})
+
+        assert excinfo.match(base._JSON_FILE_PRIVATE_KEY)
+
+    def test_from_service_account_file(self):
+        signer = _cryptography_rsa.RSASigner.from_service_account_file(
+            SERVICE_ACCOUNT_JSON_FILE)
+
+        assert signer.key_id == SERVICE_ACCOUNT_INFO[
+            base._JSON_FILE_PRIVATE_KEY_ID]
+        assert isinstance(signer._key, rsa.RSAPrivateKey)

--- a/tests/crypt/test__cryptography_rsa.py
+++ b/tests/crypt/test__cryptography_rsa.py
@@ -59,63 +59,51 @@ with open(SERVICE_ACCOUNT_JSON_FILE, 'r') as fh:
     SERVICE_ACCOUNT_INFO = json.load(fh)
 
 
-# class TestRSAVerifier(object):
-#     def test_verify_success(self):
-#         to_sign = b'foo'
-#         signer = _python_rsa.RSASigner.from_string(PRIVATE_KEY_BYTES)
-#         actual_signature = signer.sign(to_sign)
+class TestRSAVerifier(object):
+    def test_verify_success(self):
+        to_sign = b'foo'
+        signer = _cryptography_rsa.RSASigner.from_string(PRIVATE_KEY_BYTES)
+        actual_signature = signer.sign(to_sign)
 
-#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
-#         assert verifier.verify(to_sign, actual_signature)
+        verifier = _cryptography_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
+        assert verifier.verify(to_sign, actual_signature)
 
-#     def test_verify_unicode_success(self):
-#         to_sign = u'foo'
-#         signer = _python_rsa.RSASigner.from_string(PRIVATE_KEY_BYTES)
-#         actual_signature = signer.sign(to_sign)
+    def test_verify_unicode_success(self):
+        to_sign = u'foo'
+        signer = _cryptography_rsa.RSASigner.from_string(PRIVATE_KEY_BYTES)
+        actual_signature = signer.sign(to_sign)
 
-#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
-#         assert verifier.verify(to_sign, actual_signature)
+        verifier = _cryptography_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
+        assert verifier.verify(to_sign, actual_signature)
 
-#     def test_verify_failure(self):
-#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
-#         bad_signature1 = b''
-#         assert not verifier.verify(b'foo', bad_signature1)
-#         bad_signature2 = b'a'
-#         assert not verifier.verify(b'foo', bad_signature2)
+    def test_verify_failure(self):
+        verifier = _cryptography_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
+        bad_signature1 = b''
+        assert not verifier.verify(b'foo', bad_signature1)
+        bad_signature2 = b'a'
+        assert not verifier.verify(b'foo', bad_signature2)
 
-#     def test_from_string_pub_key(self):
-#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
-#         assert isinstance(verifier, _python_rsa.RSAVerifier)
-#         assert isinstance(verifier._pubkey, rsa.key.PublicKey)
+    def test_from_string_pub_key(self):
+        verifier = _cryptography_rsa.RSAVerifier.from_string(PUBLIC_KEY_BYTES)
+        assert isinstance(verifier, _cryptography_rsa.RSAVerifier)
+        assert isinstance(verifier._pubkey, rsa.RSAPublicKey)
 
-#     def test_from_string_pub_key_unicode(self):
-#         public_key = _helpers.from_bytes(PUBLIC_KEY_BYTES)
-#         verifier = _python_rsa.RSAVerifier.from_string(public_key)
-#         assert isinstance(verifier, _python_rsa.RSAVerifier)
-#         assert isinstance(verifier._pubkey, rsa.key.PublicKey)
+    def test_from_string_pub_key_unicode(self):
+        public_key = _helpers.from_bytes(PUBLIC_KEY_BYTES)
+        verifier = _cryptography_rsa.RSAVerifier.from_string(public_key)
+        assert isinstance(verifier, _cryptography_rsa.RSAVerifier)
+        assert isinstance(verifier._pubkey, rsa.RSAPublicKey)
 
-#     def test_from_string_pub_cert(self):
-#         verifier = _python_rsa.RSAVerifier.from_string(PUBLIC_CERT_BYTES)
-#         assert isinstance(verifier, _python_rsa.RSAVerifier)
-#         assert isinstance(verifier._pubkey, rsa.key.PublicKey)
+    def test_from_string_pub_cert(self):
+        verifier = _cryptography_rsa.RSAVerifier.from_string(PUBLIC_CERT_BYTES)
+        assert isinstance(verifier, _cryptography_rsa.RSAVerifier)
+        assert isinstance(verifier._pubkey, rsa.RSAPublicKey)
 
-#     def test_from_string_pub_cert_unicode(self):
-#         public_cert = _helpers.from_bytes(PUBLIC_CERT_BYTES)
-#         verifier = _python_rsa.RSAVerifier.from_string(public_cert)
-#         assert isinstance(verifier, _python_rsa.RSAVerifier)
-#         assert isinstance(verifier._pubkey, rsa.key.PublicKey)
-
-#     def test_from_string_pub_cert_failure(self):
-#         cert_bytes = PUBLIC_CERT_BYTES
-#         true_der = rsa.pem.load_pem(cert_bytes, 'CERTIFICATE')
-#         load_pem_patch = mock.patch(
-#             'rsa.pem.load_pem', return_value=true_der + b'extra',
-#             autospec=True)
-
-#         with load_pem_patch as load_pem:
-#             with pytest.raises(ValueError):
-#                 _python_rsa.RSAVerifier.from_string(cert_bytes)
-#             load_pem.assert_called_once_with(cert_bytes, 'CERTIFICATE')
+    def test_from_string_pub_cert_unicode(self):
+        public_cert = _helpers.from_bytes(PUBLIC_CERT_BYTES)
+        verifier = _cryptography_rsa.RSAVerifier.from_string(public_cert)
+        assert isinstance(verifier, _cryptography_rsa.RSAVerifier)
+        assert isinstance(verifier._pubkey, rsa.RSAPublicKey)
 
 
 class TestRSASigner(object):

--- a/tests/crypt/test__python_rsa.py
+++ b/tests/crypt/test__python_rsa.py
@@ -23,6 +23,7 @@ import six
 
 from google.auth import _helpers
 from google.auth.crypt import _python_rsa
+from google.auth.crypt import base
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
@@ -176,19 +177,19 @@ class TestRSASigner(object):
             SERVICE_ACCOUNT_INFO)
 
         assert signer.key_id == SERVICE_ACCOUNT_INFO[
-            _python_rsa._JSON_FILE_PRIVATE_KEY_ID]
+            base._JSON_FILE_PRIVATE_KEY_ID]
         assert isinstance(signer._key, rsa.key.PrivateKey)
 
     def test_from_service_account_info_missing_key(self):
         with pytest.raises(ValueError) as excinfo:
             _python_rsa.RSASigner.from_service_account_info({})
 
-        assert excinfo.match(_python_rsa._JSON_FILE_PRIVATE_KEY)
+        assert excinfo.match(base._JSON_FILE_PRIVATE_KEY)
 
     def test_from_service_account_file(self):
         signer = _python_rsa.RSASigner.from_service_account_file(
             SERVICE_ACCOUNT_JSON_FILE)
 
         assert signer.key_id == SERVICE_ACCOUNT_INFO[
-            _python_rsa._JSON_FILE_PRIVATE_KEY_ID]
+            base._JSON_FILE_PRIVATE_KEY_ID]
         assert isinstance(signer._key, rsa.key.PrivateKey)

--- a/tests/test__service_account_info.py
+++ b/tests/test__service_account_info.py
@@ -42,7 +42,7 @@ def test_from_dict_bad_private_key():
     with pytest.raises(ValueError) as excinfo:
         _service_account_info.from_dict(info)
 
-    assert excinfo.match(r'No key could be detected')
+    assert excinfo.match(r'key')
 
 
 def test_from_dict_bad_format():

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
   requests
   requests-oauthlib
   urllib3
+  cryptography
   grpcio; platform_python_implementation != 'PyPy'
 commands =
   py.test --cov=google.auth --cov=google.oauth2 --cov=tests {posargs:tests}


### PR DESCRIPTION
Fixes #183.

NOTE: This change is incomplete. It needs unit tests and a `Verifier` implementation.

Big H/T to @arthurdarcet for the implementation.