### PR TITLE
Fix 161: Add error message to handle case of empty string for GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -58,14 +58,18 @@ def _load_credentials_from_file(filename):
 
     Raises:
         google.auth.exceptions.DefaultCredentialsError: if the file is in the
-            wrong format.
+            wrong format or is missing.
     """
-    with io.open(filename, 'r') as file_obj:
-        try:
-            info = json.load(file_obj)
-        except ValueError as exc:
-            raise exceptions.DefaultCredentialsError(
-                'File {} is not a valid json file.'.format(filename), exc)
+    try:
+        with io.open(filename, 'r') as file_obj:
+            try:
+                info = json.load(file_obj)
+            except ValueError as exc:
+                raise exceptions.DefaultCredentialsError(
+                    'File {} is not a valid json file.'.format(filename), exc)
+    except IOError as exc:
+        raise exceptions.DefaultCredentialsError(
+            'File {} was not found.'.format(filename), exc)
 
     # The type key should indicate that the file is either a service account
     # credentials file or an authorized user credentials file.

--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -60,16 +60,16 @@ def _load_credentials_from_file(filename):
         google.auth.exceptions.DefaultCredentialsError: if the file is in the
             wrong format or is missing.
     """
-    try:
-        with io.open(filename, 'r') as file_obj:
-            try:
-                info = json.load(file_obj)
-            except ValueError as exc:
-                raise exceptions.DefaultCredentialsError(
-                    'File {} is not a valid json file.'.format(filename), exc)
-    except IOError as exc:
+    if not os.path.exists(filename):
         raise exceptions.DefaultCredentialsError(
-            'File {} was not found.'.format(filename), exc)
+            'File {} was not found.'.format(filename))
+
+    with io.open(filename, 'r') as file_obj:
+        try:
+            info = json.load(file_obj)
+        except ValueError as exc:
+            raise exceptions.DefaultCredentialsError(
+                'File {} is not a valid json file.'.format(filename), exc)
 
     # The type key should indicate that the file is either a service account
     # credentials file or an authorized user credentials file.

--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -42,10 +42,11 @@ LOAD_FILE_PATCH = mock.patch(
     'google.auth._default._load_credentials_from_file', return_value=(
         mock.sentinel.credentials, mock.sentinel.project_id), autospec=True)
 
+
 def test__load_credentials_from_missing_file():
     with pytest.raises(exceptions.DefaultCredentialsError) as excinfo:
         _default._load_credentials_from_file('')
-    
+
     assert excinfo.match(r'not found')
 
 

--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -48,6 +48,7 @@ def test__load_credentials_from_missing_file():
     
     assert excinfo.match(r'not found')
 
+
 def test__load_credentials_from_file_invalid_json(tmpdir):
     jsonfile = tmpdir.join('invalid.json')
     jsonfile.write('{')

--- a/tests/test__default.py
+++ b/tests/test__default.py
@@ -42,6 +42,11 @@ LOAD_FILE_PATCH = mock.patch(
     'google.auth._default._load_credentials_from_file', return_value=(
         mock.sentinel.credentials, mock.sentinel.project_id), autospec=True)
 
+def test__load_credentials_from_missing_file():
+    with pytest.raises(exceptions.DefaultCredentialsError) as excinfo:
+        _default._load_credentials_from_file('')
+    
+    assert excinfo.match(r'not found')
 
 def test__load_credentials_from_file_invalid_json(tmpdir):
     jsonfile = tmpdir.join('invalid.json')


### PR DESCRIPTION
Fixes #161 according to @jonparrott's recommendation