### PR TITLE
Fix OAuth2 credentials to inherit from ReadOnlyScoped instead of Scoped.

### DIFF
--- a/google/oauth2/credentials.py
+++ b/google/oauth2/credentials.py
@@ -36,7 +36,7 @@ from google.auth import credentials
 from google.oauth2 import _client
 
 
-class Credentials(credentials.Scoped, credentials.Credentials):
+class Credentials(credentials.ReadOnlyScoped, credentials.Credentials):
     """Credentials using OAuth 2.0 access and refresh tokens."""
 
     def __init__(self, token, refresh_token=None, id_token=None,
@@ -108,15 +108,6 @@ class Credentials(credentials.Scoped, credentials.Credentials):
         """False: OAuth 2.0 credentials have their scopes set when
         the initial token is requested and can not be changed."""
         return False
-
-    def with_scopes(self, scopes):
-        """Unavailable, OAuth 2.0 credentials can not be re-scoped.
-
-        OAuth 2.0 credentials have their scopes set when the initial token is
-        requested and can not be changed.
-        """
-        raise NotImplementedError(
-            'OAuth 2.0 Credentials can not modify their scopes.')
 
     @_helpers.copy_docstring(credentials.Credentials)
     def refresh(self, request):

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -48,11 +48,6 @@ class TestCredentials(object):
         assert credentials.client_id == self.CLIENT_ID
         assert credentials.client_secret == self.CLIENT_SECRET
 
-    def test_create_scoped(self):
-        credentials = self.make_credentials()
-        with pytest.raises(NotImplementedError):
-            credentials.with_scopes(['email'])
-
     @mock.patch('google.oauth2._client.refresh_grant', autospec=True)
     @mock.patch(
         'google.auth._helpers.utcnow',

--- a/tests/oauth2/test_credentials.py
+++ b/tests/oauth2/test_credentials.py
@@ -15,7 +15,6 @@
 import datetime
 
 import mock
-import pytest
 
 from google.auth import _helpers
 from google.auth import transport


### PR DESCRIPTION
This is an issue when using spanner client APIs. https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4010. Having OAuth2 credentials inherit from ReadOnlyScoped instead of Scoped will fix that.