### PR TITLE
Updated the doc with python setup guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,10 @@ You can install using `pip`_::
 
 .. _pip: https://pip.pypa.io/en/stable/
 
+For more information on setting up your Python development environment, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _`Python Development Environment Setup Guide`: https://cloud.google.com/python/setup
+
 Documentation
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,10 @@ google-auth can be installed with `pip`_::
 google-auth is open-source, so you can alternatively grab the source code from
 `GitHub`_ and install from source.
 
+
+For more information on setting up your Python development environment, please refer to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
+
+.. _`Python Development Environment Setup Guide`: https://cloud.google.com/python/setup
 .. _pip: https://pip.pypa.io
 .. _GitHub: https://github.com/GoogleCloudPlatform/google-auth-library-python
 


### PR DESCRIPTION
As requested in b/64770713.

The package is referenced in some of the BigQuery documentation; considering the structure of the documents it might be better to add the link to python setup guide here.