### PR TITLE
Retry OAuth 2.0 token refresh requests at network errors on layers lower than HTTP

### DIFF
--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -155,9 +155,10 @@ class AuthorizedSession(requests.Session):
         # credentials.refresh).
         # Do not pass `self` as the session here, as it can lead to infinite
         # recursion.
-        sess = requests.Session()
-        sess.mount("https://", requests.adapters.HTTPAdapter(max_retries=3))
-        self._auth_request = Request(sess)
+        auth_request_session = requests.Session()
+        retry_adapter = requests.adapters.HTTPAdapter(max_retries=3)
+        auth_request_session.mount("https://", retry_adapter)
+        self._auth_request = Request(auth_request_session)
 
     def request(self, method, url, data=None, headers=None, **kwargs):
         """Implementation of Requests' request."""

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -208,7 +208,14 @@ class AuthorizedSession(requests.Session):
 
             try:
                 self.credentials.refresh(self._auth_request)
-            except requests.Timeout:
+            except requests.ReadTimeout:
+                # This exception is not catched by requests.adapter
+                # defined in __init__()
+                # because POST is not considered a retryable HTTP method
+                # when it reaches to the peers.
+                # We here silently ignore the exception and
+                # make the next recursive call
+                # increment _credential_refresh_attempt and retry refresh.
                 pass
 
             # Recurse. Pass in the original headers, not our modified set.

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -194,7 +194,10 @@ class AuthorizedSession(requests.Session):
                 response.status_code, _credential_refresh_attempt + 1,
                 self._max_refresh_attempts)
 
-            self.credentials.refresh(self._auth_request)
+            try:
+                self.credentials.refresh(self._auth_request)
+            except requests.Timeout:
+                pass
 
             # Recurse. Pass in the original headers, not our modified set.
             return self.request(

--- a/google/auth/transport/requests.py
+++ b/google/auth/transport/requests.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: NO COVER
     raise ImportError(
         'The requests library is not installed, please install the requests '
         'package to use the requests transport.')
+import requests.adapters
 import requests.exceptions
 
 from google.auth import exceptions
@@ -154,7 +155,9 @@ class AuthorizedSession(requests.Session):
         # credentials.refresh).
         # Do not pass `self` as the session here, as it can lead to infinite
         # recursion.
-        self._auth_request = Request()
+        sess = requests.Session()
+        sess.mount("https://", requests.adapters.HTTPAdapter(max_retries=3))
+        self._auth_request = Request(sess)
 
     def request(self, method, url, data=None, headers=None, **kwargs):
         """Implementation of Requests' request."""

--- a/google/oauth2/_client.py
+++ b/google/oauth2/_client.py
@@ -101,7 +101,7 @@ def _token_endpoint_request(request, token_uri, body):
     }
 
     response = request(
-        method='POST', url=token_uri, headers=headers, body=body)
+        method='POST', url=token_uri, headers=headers, body=body, timeout=10)
 
     response_body = response.data.decode('utf-8')
 

--- a/tests/oauth2/test__client.py
+++ b/tests/oauth2/test__client.py
@@ -76,7 +76,8 @@ def test__token_endpoint_request():
         method='POST',
         url='http://example.com',
         headers={'content-type': 'application/x-www-form-urlencoded'},
-        body='test=params')
+        body='test=params',
+        timeout=10)
 
     # Check result
     assert result == {'test': 'response'}


### PR DESCRIPTION
`https://accounts.google.com/` does NOT send TCP FIN packets nor RST when it closes connections (see the tcpdump's output below).
This makes the requests library (precisely the underlying urllib3 library) mistakenly reuse an actually-closed connection from its connection pools for OAuth 2.0 token refresh HTTP requests, resulting in long time blocking or the `104: Connection reset by peer` error.

My first commit handles `Connection reset by peer` using requests' adapters.

The second commit is for the blocking behaviours and sets the `timeout` parameter to a HTTP request function to make them raise `requests.Timeout` exception and retry refresh requests when catches it.
Simply setting the `timeout` parameter is not enough, because the users of this library cannot determine whether the exception is from the token refresh HTTP requests (which I think can be safely retried) or from their own ones (which might not be idempotent nor able to be retried).
This commit might not be good though because it changes the default timeout behaviour of this library with the HTTP libraries other than requests.

I also encourage you to stop using `requests.Session` (and thus the urllib3's connection pool) as a better enhancement since it is nonsense to pool connections for OAuth token refresh which occurs as infrequently as every one hour in most cases.

### How to Reproduce

The code to reproduce this behaviour is below (it does not use the google-auth library but rather emulates its internal behaviour of version 1.1.1):


```python
#!/usr/bin/env python
import requests
import logging
import sys
from time import sleep

url = sys.argv[1]

logging.basicConfig()
logging.getLogger().setLevel(logging.DEBUG)
requests_log = logging.getLogger("urllib3")
requests_log.setLevel(logging.DEBUG)

s = requests.Session()
s.get(url, allow_redirects=False)
print("sleep for 200 sec.")
sleep(200)
print("try GET now")
s.get(url, allow_redirects=False)  # Block forever!
```

console output:


```console
$ ./request_twice.py https://accounts.google.com/
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): accounts.google.com
DEBUG:urllib3.connectionpool:https://accounts.google.com:443 "GET / HTTP/1.1" 302 272
sleep for 200 sec.
try GET now
```

### Environments

Whether blocking or raising the error depends on clients' environments.
I have not investigate the reason.

I observed blocking behaviour on my Linux laptop:

```console
$ uname -a
Linux MY-COMPUTER 4.4.0-96-generic #119-Ubuntu SMP Tue Sep 12 14:59:54 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
$ python
Python 3.5.2 (default, Sep 14 2017, 22:51:06) 
[GCC 5.4.0 20160609] on linux
```

`104: Connection reset by peer` occured on docker containers on the same laptop:

```console
$ docker -v
Docker version 17.05.0-ce, build 89658be
$ docker run -it python:latest python  # same on python:3.5.2
Python 3.6.3 (default, Oct 10 2017, 02:29:16) 
[GCC 4.9.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```

### Details of Behaviour


the `ss` result while running the script (not in docker):

```console
$ sudo ss -6
Netid  State      Recv-Q Send-Q                                         Local Address:Port                                                          Peer Address:Port                
tcp    ESTAB      0      0                       $MY_IPV6_ADDRESS:60242                                             2404:6800:4004:800::200d:https                
```

tcpdump's output (not in docker):

```console
$ sudo tcpdump -n -i wlan0 host $MY_IPV6_ADDRESS
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on wlan0, link-type EN10MB (Ethernet), capture size 262144 bytes
15:56:17.667518 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [S], seq 1049022341, win 28800, options [mss 1440,sackOK,TS val 4913892 ecr 0,nop,wscale 7], length 0
15:56:17.673056 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [S.], seq 4274619975, ack 1049022342, win 26960, options [mss 1280,sackOK,TS val 984523980 ecr 4913892,nop,wscale 8], length 0
15:56:17.673104 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [.], ack 1, win 225, options [nop,nop,TS val 4913894 ecr 984523980], length 0
15:56:17.680851 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [P.], seq 1:518, ack 1, win 225, options [nop,nop,TS val 4913895 ecr 984523980], length 517
15:56:17.686796 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [.], ack 518, win 110, options [nop,nop,TS val 984523993 ecr 4913895], length 0
15:56:17.721061 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [.], seq 1:1209, ack 518, win 110, options [nop,nop,TS val 984524028 ecr 4913895], length 1208
15:56:17.721099 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [.], ack 1209, win 244, options [nop,nop,TS val 4913906 ecr 984524028], length 0
15:56:17.723699 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [.], seq 1209:2417, ack 518, win 110, options [nop,nop,TS val 984524028 ecr 4913895], length 1208
15:56:17.723795 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [.], ack 2417, win 263, options [nop,nop,TS val 4913906 ecr 984524028], length 0
15:56:17.726215 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [P.], seq 2417:3604, ack 518, win 110, options [nop,nop,TS val 984524028 ecr 4913895], length 1187
15:56:17.726275 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [.], ack 3604, win 282, options [nop,nop,TS val 4913907 ecr 984524028], length 0
15:56:17.727292 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [P.], seq 518:644, ack 3604, win 282, options [nop,nop,TS val 4913907 ecr 984524028], length 126
15:56:17.734682 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [P.], seq 3604:3883, ack 644, win 110, options [nop,nop,TS val 984524039 ecr 4913907], length 279
15:56:17.737646 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [P.], seq 644:823, ack 3883, win 301, options [nop,nop,TS val 4913910 ecr 984524039], length 179
15:56:17.781355 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [.], ack 823, win 114, options [nop,nop,TS val 984524049 ecr 4913910], length 0
15:56:17.782759 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [P.], seq 3883:4389, ack 823, win 114, options [nop,nop,TS val 984524090 ecr 4913910], length 506
15:56:17.783643 IP6 2404:6800:4004:800::200d.443 > $MY_IPV6_ADDRESS.34876: Flags [P.], seq 4389:4641, ack 823, win 114, options [nop,nop,TS val 984524090 ecr 4913910], length 252
15:56:17.785665 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [.], ack 4641, win 339, options [nop,nop,TS val 4913922 ecr 984524090], length 0
15:56:22.689129 IP6 240b:10:2640:bf0::1 > $MY_IPV6_ADDRESS: ICMP6, neighbor solicitation, who has $MY_IPV6_ADDRESS, length 32
15:56:22.689198 IP6 $MY_IPV6_ADDRESS > 240b:10:2640:bf0::1: ICMP6, neighbor advertisement, tgt is $MY_IPV6_ADDRESS, length 24
15:59:37.892893 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [P.], seq 823:1002, ack 4641, win 339, options [nop,nop,TS val 4963948 ecr 984524090], length 179
15:59:38.101194 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [P.], seq 823:1002, ack 4641, win 339, options [nop,nop,TS val 4964001 ecr 984524090], length 179
15:59:38.313336 IP6 $MY_IPV6_ADDRESS.34876 > 2404:6800:4004:800::200d.443: Flags [P.], seq 823:1002, ack 4641, win 339, options [nop,nop,TS val 4964054 ecr 984524090], length 179

... repeating the same packet ...

^C
26 packets captured
26 packets received by filter
0 packets dropped by kernel
```
