### PR TITLE
Drop direct pyasn1 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ from setuptools import setup
 
 
 DEPENDENCIES = (
-    'pyasn1>=0.1.7',
-    'pyasn1-modules>=0.0.5',
+    'pyasn1-modules>=0.2.1',
     'rsa>=3.1.4',
     'six>=1.9.0',
     'cachetools>=2.0.0',


### PR DESCRIPTION
Instead, rely on pyasn1-modules to pull the appropriate version.