### PR TITLE
Making the dependency on app_engine unnecessary.

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -172,13 +172,13 @@ def _get_explicit_environ_credentials():
 
 def _get_gae_credentials():
     """Gets Google App Engine App Identity credentials and project ID."""
-    from google.auth import app_engine
-
     try:
+        from google.auth import app_engine
+
         credentials = app_engine.Credentials()
         project_id = app_engine.get_project_id()
         return credentials, project_id
-    except EnvironmentError:
+    except (ImportError, EnvironmentError):
         return None, None
 
 


### PR DESCRIPTION
For code running in GCE, not GAE it doesn't make sense to force the
dependency on app_engine just to use GCE auth.