### PR TITLE
Allow error text of Python 3.7

### DIFF
--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -118,7 +118,7 @@ def test_decode_bad_token_wrong_number_of_segments():
 def test_decode_bad_token_not_base64():
     with pytest.raises((ValueError, TypeError)) as excinfo:
         jwt.decode('1.2.3', PUBLIC_CERT_BYTES)
-    assert excinfo.match(r'Incorrect padding')
+    assert excinfo.match(r'Incorrect padding|more than a multiple of 4')
 
 
 def test_decode_bad_token_not_json():


### PR DESCRIPTION
Fixes the following test failure under Python 3.7:

```
=================================== FAILURES ===================================
_______________________ test_decode_bad_token_not_base64 _______________________

    def test_decode_bad_token_not_base64():
        with pytest.raises((ValueError, TypeError)) as excinfo:
            jwt.decode('1.2.3', PUBLIC_CERT_BYTES)
>       assert excinfo.match(r'Incorrect padding')
E       AssertionError: Pattern 'Incorrect padding' not found in 'Invalid base64-encoded string: length cannot be 1 more than a multiple of 4'

tests/test_jwt.py:121: AssertionError
======== 1 failed, 280 passed, 4 skipped, 1 deselected in 21.03 seconds ========
```