### PR TITLE
Remove punctuation which becomes part of the url

### DIFF
--- a/google/auth/_default.py
+++ b/google/auth/_default.py
@@ -41,7 +41,7 @@ _HELP_MESSAGE = """\
 Could not automatically determine credentials. Please set {env} or \
 explicitly create credentials and re-run the application. For more \
 information, please see \
-https://developers.google.com/accounts/docs/application-default-credentials.
+https://developers.google.com/accounts/docs/application-default-credentials
 """.format(env=environment_vars.CREDENTIALS).strip()
 
 # Warning when using Cloud SDK user credentials
@@ -51,7 +51,7 @@ Cloud SDK. We recommend that most server applications use service accounts \
 instead. If your application continues to use end user credentials from Cloud \
 SDK, you might receive a "quota exceeded" or "API not enabled" error. For \
 more information about service accounts, see \
-https://cloud.google.com/docs/authentication/."""
+https://cloud.google.com/docs/authentication/"""
 
 
 def _warn_about_problematic_credentials(credentials):


### PR DESCRIPTION
In colab and likely other applications, the period is incorrectly bound into the url, which is then invalid and produces a 404

DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or
explicitly create credential and re-run the application. For more
information, please see
https://developers.google.com/accounts/docs/application-default-credentials.