### PR TITLE
Enable pytype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ tests/data/user-key.json
 # Generated files
 pylintrc
 pylintrc.test
+pytype_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ cache:
   directories:
   - ${HOME}/.cache
 install:
-- pip install --upgrade tox
-- pip install --upgrade pytype
+- pip install --upgrade tox pytype
 script:
 - scripts/travis.sh
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ cache:
   - ${HOME}/.cache
 install:
 - pip install --upgrade tox
+- pip install --upgrade pytype
 script:
 - scripts/travis.sh
 deploy:

--- a/google/__init__.py
+++ b/google/__init__.py
@@ -19,5 +19,4 @@ try:
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
-    __path__ = pkgutil.extend_path(__path__,  # pytype: disable=name-error
-                                   __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/google/__init__.py
+++ b/google/__init__.py
@@ -19,4 +19,4 @@ try:
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)  # pytype: disable=name-error

--- a/google/__init__.py
+++ b/google/__init__.py
@@ -19,4 +19,5 @@ try:
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)  # pytype: disable=name-error
+    __path__ = pkgutil.extend_path(__path__,  # pytype: disable=name-error
+                                   __name__)

--- a/google/auth/_oauth2client.py
+++ b/google/auth/_oauth2client.py
@@ -25,19 +25,22 @@ import six
 
 from google.auth import _helpers
 import google.auth.app_engine
+import google.auth.compute_engine
 import google.oauth2.credentials
 import google.oauth2.service_account
 
 try:
+    # pytype: disable=import-error
     import oauth2client.client
     import oauth2client.contrib.gce
     import oauth2client.service_account
+    # pytype: enable=import-error
 except ImportError as caught_exc:
     six.raise_from(
         ImportError('oauth2client is not installed.'), caught_exc)
 
 try:
-    import oauth2client.contrib.appengine
+    import oauth2client.contrib.appengine  # pytype: disable=import-error
     _HAS_APPENGINE = True
 except ImportError:
     _HAS_APPENGINE = False

--- a/google/auth/app_engine.py
+++ b/google/auth/app_engine.py
@@ -28,10 +28,12 @@ from google.auth import _helpers
 from google.auth import credentials
 from google.auth import crypt
 
+# pytype: disable=import-error
 try:
-    from google.appengine.api import app_identity  # pytype: disable=import-error
+    from google.appengine.api import app_identity
 except ImportError:
     app_identity = None
+# pytype: enable=import-error
 
 
 class Signer(crypt.Signer):

--- a/google/auth/app_engine.py
+++ b/google/auth/app_engine.py
@@ -29,7 +29,7 @@ from google.auth import credentials
 from google.auth import crypt
 
 try:
-    from google.appengine.api import app_identity
+    from google.appengine.api import app_identity  # pytype: disable=import-error
 except ImportError:
     app_identity = None
 

--- a/google/auth/crypt/_cryptography_rsa.py
+++ b/google/auth/crypt/_cryptography_rsa.py
@@ -19,12 +19,14 @@ This is a much faster implementation than the default (in
 ``rsa`` library.
 """
 
+# pytype: disable=import-error
 import cryptography.exceptions
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 import cryptography.x509
+# pytype: enable=import-error
 import pkg_resources
 
 from google.auth import _helpers

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -46,7 +46,7 @@ import copy
 import datetime
 import json
 
-import cachetools  # pytype: disable=import-error
+import cachetools
 import six
 from six.moves import urllib
 

--- a/google/auth/jwt.py
+++ b/google/auth/jwt.py
@@ -46,7 +46,7 @@ import copy
 import datetime
 import json
 
-import cachetools
+import cachetools  # pytype: disable=import-error
 import six
 from six.moves import urllib
 
@@ -738,7 +738,7 @@ class OnDemandCredentials(
         parts = urllib.parse.urlsplit(url)
         # Strip query string and fragment
         audience = urllib.parse.urlunsplit(
-            (parts.scheme, parts.netloc, parts.path, None, None))
+            (parts.scheme, parts.netloc, parts.path, "", ""))
         token = self._get_jwt_for_audience(audience)
         self.apply(headers, token=token)
 

--- a/google/auth/transport/grpc.py
+++ b/google/auth/transport/grpc.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 
 import six
 try:
-    import grpc
+    import grpc  # pytype: disable=import-error
 except ImportError as caught_exc:  # pragma: NO COVER
     six.raise_from(
         ImportError(

--- a/google/auth/transport/urllib3.py
+++ b/google/auth/transport/urllib3.py
@@ -31,7 +31,7 @@ except ImportError:  # pragma: NO COVER
     certifi = None
 
 try:
-    import urllib3
+    import urllib3  # pytype: disable=import-error
 except ImportError as caught_exc:  # pragma: NO COVER
     import six
     six.raise_from(
@@ -42,7 +42,9 @@ except ImportError as caught_exc:  # pragma: NO COVER
         caught_exc,
     )
 import six
+# pytype: disable=import-error
 import urllib3.exceptions  # pylint: disable=ungrouped-imports
+# pytype: enable=import-error
 
 from google.auth import exceptions
 from google.auth import transport

--- a/scripts/obtain_user_auth.py
+++ b/scripts/obtain_user_auth.py
@@ -23,8 +23,10 @@ specifically for testing.
 import json
 import os
 
+# pytype: disable=import-error
 from oauth2client import client
 from oauth2client import tools
+# pytype: disable=import-error
 
 HERE = os.path.dirname(__file__)
 CLIENT_SECRETS_PATH = os.path.abspath(os.path.join(

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -40,3 +40,7 @@ fi
 # Run tox.
 echo "Running tox..."
 tox
+
+# Run pytype.
+echo "Running pytype..."
+pytype

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,17 @@
 [bdist_wheel]
 universal = 1
+
+[pytype]
+# Where to start analysis.
+inputs = .
+# Some files aren't worth analyzing, namely tests. Hidden directories (e.g.
+# .tox) are automatically filtered out.
+exclude = tests system_tests
+# All pytype output goes here.
+output = pytype_output
+# Python version (major.minor) of the target code.
+python_version = 3.6
+# Paths to source code directories, separated by ':'.
+pythonpath = .
+# Errors to disable.
+disable = pyi-error


### PR DESCRIPTION
A few notes:
- Fixes type errors detected by pytype.
- setup.cfg disables pytype's `pyi-error`. This is necessary due to incomplete type stubs in https://github.com/python/typeshed.
- This only enables pytype's Python3.6 checks. Python2.7 is supported by pytype but incomplete type stubs cause spurious type errors.

These changes do not add, remove or change any part of the API.